### PR TITLE
chore: add MIT license and improve issue templates (#36)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord Community
+    url: https://discord.gg/operum
+    about: Quick questions and real-time support
+  - name: Documentation
+    url: https://operum.ai/docs
+    about: Read the docs first

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,0 +1,19 @@
+---
+name: General Feedback
+about: Share thoughts, suggestions, or general feedback
+title: '[Feedback] '
+labels: type:feedback
+assignees: ''
+---
+
+## What would you like to share?
+
+Your feedback, thoughts, or suggestions about Operum.
+
+## Context / Use Case
+
+What were you doing or trying to achieve? How does this relate to your workflow?
+
+## Additional Context
+
+Any other relevant information, screenshots, or references.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Operum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
<!-- operum-agent: engineer -->
## 💻 Summary

Closes #36

Adds MIT license (prerequisite for awesome-list submissions) and improves issue templates for better community engagement.

## Changes

### 1. MIT License (`LICENSE`)
- Standard MIT License, copyright 2026 Operum
- Unblocks awesome-list and open-source directory submissions

### 2. General Feedback Template (`.github/ISSUE_TEMPLATE/feedback.md`)
- New "General Feedback" template alongside existing Bug Report and Feature Request
- Labeled `type:feedback` for pipeline routing
- Asks for feedback content and context/use case

### 3. Issue Template Config (`.github/ISSUE_TEMPLATE/config.yml`)
- Disables blank issues (forces users to pick a template)
- Adds contact links for Discord community and documentation

## Files Changed
- `LICENSE` — new file
- `.github/ISSUE_TEMPLATE/feedback.md` — new file
- `.github/ISSUE_TEMPLATE/config.yml` — new file

---
*Software Engineer - Operum AI*