### PR TITLE
docs: add community health files (closes #32)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Code of Conduct
+
+## Our Standards
+
+We are committed to making participation in this project a welcoming experience for everyone.
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy toward other community members
+
+Examples of unacceptable behavior:
+
+- Insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that is deemed inappropriate.
+
+Instances of unacceptable behavior may be reported by contacting the project team at the email listed on our [website](https://operum.ai). All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to Operum
+
+Thanks for your interest in improving Operum! This repository is our **feedback and community hub** — it's where we collect bug reports, feature requests, and general feedback. The Operum application source code is in a separate private repository.
+
+## How to Contribute
+
+### Bug Reports
+
+Found something broken? [Create a bug report](https://github.com/alprimak/operum-feedback/issues/new?template=bug_report.md&labels=bug).
+
+A good bug report includes:
+
+- **Operum version** (shown in the bottom-left of the app)
+- **Operating system** (e.g., Ubuntu 24.04, Windows 11, macOS Sequoia)
+- **Installation method** (deb, AppImage, exe, dmg)
+- **Steps to reproduce** — the more specific, the faster we can fix it
+- **Expected behavior** — what should have happened
+- **Actual behavior** — what happened instead
+- **Screenshots** — if applicable, they're worth a thousand words
+
+### Feature Requests
+
+Have an idea? [Request a feature](https://github.com/alprimak/operum-feedback/issues/new?template=feature_request.md&labels=enhancement).
+
+A useful feature request:
+
+- **Starts with the problem** — what are you trying to do that's hard or impossible?
+- **Describes your ideal solution** — how would you like it to work?
+- **Mentions alternatives** — have you tried workarounds?
+- **Includes context** — how would this fit into your workflow?
+
+### General Feedback
+
+Thoughts, suggestions, or impressions? [Share feedback](https://github.com/alprimak/operum-feedback/issues/new?template=feedback.md&labels=type:feedback).
+
+### Template Contributions
+
+The [`templates/`](templates/) directory contains our open-source agent orchestration templates. If you've adapted them for your use case and want to share improvements:
+
+1. Fork this repository
+2. Create a branch (`docs/your-improvement`)
+3. Make your changes
+4. Open a pull request with a clear description
+
+We welcome template improvements, additional workflow patterns, and documentation enhancements.
+
+## What to Expect
+
+After you submit an issue:
+
+1. **Acknowledgment** — our team triages new issues regularly
+2. **Labeling** — your issue gets categorized and prioritized
+3. **Discussion** — we may ask clarifying questions
+4. **Resolution** — bugs get fixed, features get considered for the roadmap
+
+For time-sensitive issues, note the priority in your report.
+
+## Quick Questions?
+
+For quick questions and real-time help, join us on [Discord](https://discord.gg/operum).
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold this code.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | ✅ Yes    |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Operum, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, contact us privately:
+
+- **Email**: security@operum.ai
+- **Subject**: `[SECURITY] Brief description`
+
+Please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact
+- Any suggested mitigations (optional)
+
+We will acknowledge your report within **48 hours** and provide a resolution timeline within **7 days**.
+
+## Disclosure Policy
+
+We follow a responsible disclosure process. Once a fix is available and deployed, we will publish a security advisory on this repository.
+
+We appreciate your effort in keeping Operum and its users safe.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with guidelines for bug reports, feature requests, and template contributions
- Add `CODE_OF_CONDUCT.md` based on Contributor Covenant v2.1
- Add `SECURITY.md` with responsible disclosure process and contact details

## Changes

| File | Description |
|------|-------------|
| `CONTRIBUTING.md` | How to submit bugs, features, and template improvements |
| `CODE_OF_CONDUCT.md` | Community behavior standards |
| `SECURITY.md` | Vulnerability reporting process |

## Test plan

- [ ] Verify all three files render correctly on GitHub
- [ ] Confirm links in CONTRIBUTING.md point to correct issue templates
- [ ] Confirm CODE_OF_CONDUCT.md link in CONTRIBUTING.md works

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)