### PR TITLE
docs: prepare repo for desktop binary release hosting (#43)

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_bug.md
+++ b/.github/ISSUE_TEMPLATE/release_bug.md
@@ -1,0 +1,42 @@
+---
+name: Bug Report (specific version)
+about: Report a bug in a specific Operum release
+title: '[v] '
+labels: type:bug
+assignees: ''
+---
+
+## Version
+
+**Operum Version:** (e.g., v1.0.0 — shown in bottom-left of the app)
+
+## Environment
+
+- **OS**: (e.g., Ubuntu 24.04, Windows 11, macOS Sequoia)
+- **Installation Method**: (deb, AppImage, exe, dmg)
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected Behavior
+
+What should have happened.
+
+## Actual Behavior
+
+What actually happened.
+
+## Screenshots
+
+If applicable, add screenshots.
+
+## Additional Context
+
+Any other relevant information (logs, error messages, etc.).

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,22 @@
+## What's New
+-
+
+## Bug Fixes
+-
+
+## Installation
+
+Download the appropriate file for your platform above.
+
+| Platform | File |
+|----------|------|
+| Linux (Debian/Ubuntu) | `.deb` |
+| Linux (Universal) | `.AppImage` |
+| Windows | `.exe` |
+| macOS | `.dmg` |
+
+## Checksums
+
+```
+SHA256:
+```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@
 
 Operum (Latin: *of works*, from *opus*) automates your development, marketing, and community workflows with a team of AI agents that coordinate through a label-driven pipeline.
 
+## Download
+
+Get the latest Operum desktop app:
+
+| Platform | Download |
+|----------|----------|
+| Linux | [.deb](https://github.com/alprimak/operum-feedback/releases/latest) · [AppImage](https://github.com/alprimak/operum-feedback/releases/latest) |
+| Windows | [.exe installer](https://github.com/alprimak/operum-feedback/releases/latest) |
+| macOS | [.dmg](https://github.com/alprimak/operum-feedback/releases/latest) |
+
+[View all releases &rarr;](https://github.com/alprimak/operum-feedback/releases)
+
 ## How It Works
 
 ```mermaid


### PR DESCRIPTION
<!-- operum-agent: engineer -->
## Summary

Closes #43

Prepares the repo to host Operum desktop binary releases via GitHub Releases.

## Changes

### 1. README.md — Download Section
- Added "Download" section after the hero, before "How It Works"
- Platform table with links to latest release (Linux .deb/AppImage, Windows .exe, macOS .dmg)
- "View all releases" link

### 2. Release Bug Template (`.github/ISSUE_TEMPLATE/release_bug.md`)
- New issue template for version-specific bug reports
- Requires: version number, OS, installation method
- Labeled `type:bug`

### 3. Release Notes Template (`.github/RELEASE_TEMPLATE.md`)
- Standard release notes format: What's New, Bug Fixes, Installation table, Checksums
- Ready for use when publishing releases

### Not Touched
- `operum-attachments` release tag — left completely untouched as instructed

---
*Software Engineer - Operum AI*