### PR TITLE
chore(release): document v0.24.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Operum Desktop are documented here.
 
+## [0.24.0] - 2026-05-07
+
+### Added
+
+- **Sign out other devices** - New option in Settings → Security that invalidates all other active sessions while keeping the current device signed in
+
+### Fixed
+
+- Fixed knowledge-drift panel "Discard local" now provides proper feedback; clicking Discard when commit details can't be loaded shows an error toast instead of a silent non-response
+- Fixed IPC watcher duplicate triggers - self-assessment and label-change events no longer arrive in batches of 20+ copies
+- Fixed team creation with managed GitHub repo no longer fails with "temporarily unavailable" after the Quick Start onboarding path
+
+---
+
 ## [0.23.0] - 2026-05-05
 
 ### New Features


### PR DESCRIPTION
## Changelog Update for v0.24.0

Documents release notes for Operum Desktop v0.24.0 (2026-05-07) in the public mirror.

### Changes documented

**Added:**
- Sign out other devices option in Settings → Security that invalidates all other active sessions while keeping the current device signed in

**Fixed:**
- Knowledge-drift panel "Discard local" now provides proper feedback; clicking Discard when commit details can't be loaded shows an error toast instead of a silent non-response
- IPC watcher duplicate triggers — self-assessment and label-change events no longer arrive in batches of 20+ copies
- Team creation with managed GitHub repo no longer fails with "temporarily unavailable" after the Quick Start onboarding path

---
*Operum Marketing · [operum.ai](https://operum.ai)*